### PR TITLE
[BUGFIX] Switch to explicit targeted symlinks

### DIFF
--- a/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/SymlinkDataTask.php
+++ b/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/SymlinkDataTask.php
@@ -46,8 +46,8 @@ class SymlinkDataTask extends \TYPO3\Surf\Domain\Model\Task {
 			"cd $workingDirectory",
 			"{ [ -d {$relativeDataPath}/fileadmin ] || mkdir -p {$relativeDataPath}/fileadmin ; }",
 			"{ [ -d {$relativeDataPath}/uploads ] || mkdir -p {$relativeDataPath}/uploads ; }",
-			"ln -snvf {$relativeDataPath}/fileadmin",
-			"ln -snvf {$relativeDataPath}/uploads"
+			"ln -sf {$relativeDataPath}/fileadmin ./fileadmin",
+			"ln -sf {$relativeDataPath}/uploads ./uploads"
 		);
 		if (isset($options['directories']) && is_array($options['directories'])) {
 			foreach ($options['directories'] as $directory) {


### PR DESCRIPTION
For me, linking worked only reliable when i give it an explicit target like in the original Flow Task.

I dont see why the target should be implicit. - But maybe there's a thing I overlooked.

System: Linux 3.19.3-3, ArchLinux
