### PR TITLE
[BUGFIX] pass deployment options into packageExists helper function

### DIFF
--- a/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/AbstractCliTask.php
+++ b/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/AbstractCliTask.php
@@ -115,7 +115,7 @@ abstract class AbstractCliTask extends \TYPO3\Surf\Domain\Model\Task {
 			return 'typo3_console';
 		}
 
-		if ($this->packageExists('coreapi', $node, $application, $deployment)) {
+		if ($this->packageExists('coreapi', $node, $application, $deployment, $options)) {
 			return 'coreapi';
 		}
 

--- a/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/CompareDatabaseTask.php
+++ b/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/CompareDatabaseTask.php
@@ -29,7 +29,7 @@ class CompareDatabaseTask extends AbstractCliTask {
 	 * @return void
 	 */
 	public function execute(Node $node, Application $application, Deployment $deployment, array $options = array()) {
-		if (!$this->packageExists('coreapi', $node, $application, $deployment)) {
+		if (!$this->packageExists('coreapi', $node, $application, $deployment, $options)) {
 			throw new InvalidConfigurationException('Extension "coreapi" is not found! Make sure it is available in your project, or remove this task in your deployment configuration!', 1405527176);
 		}
 		$databaseCompareMode = isset($options['databaseCompareMode']) ? $options['databaseCompareMode'] : '2,4';

--- a/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/FlushCachesTask.php
+++ b/Packages/Application/TYPO3.Surf.CMS/Classes/TYPO3/Surf/CMS/Task/TYPO3/CMS/FlushCachesTask.php
@@ -29,7 +29,7 @@ class FlushCachesTask extends AbstractCliTask {
 	 */
 	public function execute(Node $node, Application $application, Deployment $deployment, array $options = array()) {
 		$this->executeCliCommand(
-			$this->getSuitableCliArguments($node, $application, $deployment),
+			$this->getSuitableCliArguments($node, $application, $deployment, $options),
 			$node,
 			$application,
 			$deployment,
@@ -41,11 +41,12 @@ class FlushCachesTask extends AbstractCliTask {
 	 * @param Node $node
 	 * @param Application $application
 	 * @param Deployment $deployment
+	 * @param array $options
 	 * @return array
 	 * @throws InvalidConfigurationException
 	 */
-	protected function getSuitableCliArguments(Node $node, Application $application, Deployment $deployment) {
-		switch ($this->getAvailableCliPackage($node, $application, $deployment)) {
+	protected function getSuitableCliArguments(Node $node, Application $application, Deployment $deployment, array $options = array()) {
+		switch ($this->getAvailableCliPackage($node, $application, $deployment, $options)) {
 			case 'typo3_console':
 				return array('./typo3cms', 'cache:flush', '--force');
 			case 'coreapi':


### PR DESCRIPTION
If the 'applicationRootDirectory' is set, the CompareDatabaseTask does not find my coreapi package. I think this is because the 'applicationRootDirectory' option does not get passed into CompareDatabaseTask::packageExists. 
